### PR TITLE
fix: Boot issues with ExitStrategy enum

### DIFF
--- a/src/main/kotlin/xyz/avalonxr/config/AppSettings.kt
+++ b/src/main/kotlin/xyz/avalonxr/config/AppSettings.kt
@@ -2,7 +2,7 @@ package xyz.avalonxr.config
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
-import xyz.avalonxr.enums.ExitHandlerStrategy
+import xyz.avalonxr.enums.ExitStrategy
 import xyz.avalonxr.handler.exit.LogOnExit
 
 /**
@@ -19,5 +19,5 @@ data class AppSettings(
      * [LogOnExit] should the config value not be provided, or considered invalid.
      */
     @Value("\${avalon.exit.strategy:LOG}")
-    val exitStrategy: ExitHandlerStrategy
+    val exitStrategy: ExitStrategy
 )

--- a/src/main/kotlin/xyz/avalonxr/enums/ExitStrategy.kt
+++ b/src/main/kotlin/xyz/avalonxr/enums/ExitStrategy.kt
@@ -17,22 +17,20 @@ import xyz.avalonxr.handler.exit.LogOnExit
  * @see DebugOnExit
  */
 @Suppress("unused")
-enum class ExitHandlerStrategy(
-    val handler: ApplicationExitHandler
-) {
+enum class ExitStrategy {
 
     /**
      * Log exit as INFO or ERROR for each shutdown signal corresponding to if the exit code maps to an error.
      */
-    LOG(LogOnExit),
+    LOG,
 
     /**
      * Throw an exception whenever a shutdown signal mapping to an error code is received.
      */
-    EXCEPTION(ExceptionOnError),
+    EXCEPTION,
 
     /**
      * Silently log all shutdown signals at DEBUG level.
      */
-    DEBUG(DebugOnExit),
+    DEBUG,
 }

--- a/src/main/kotlin/xyz/avalonxr/provider/ExitStrategyHandleProvider.kt
+++ b/src/main/kotlin/xyz/avalonxr/provider/ExitStrategyHandleProvider.kt
@@ -1,0 +1,22 @@
+package xyz.avalonxr.provider
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import xyz.avalonxr.config.AppSettings
+import xyz.avalonxr.enums.ExitStrategy
+import xyz.avalonxr.handler.exit.ApplicationExitHandler
+import xyz.avalonxr.handler.exit.DebugOnExit
+import xyz.avalonxr.handler.exit.ExceptionOnError
+import xyz.avalonxr.handler.exit.LogOnExit
+
+@Component
+class ExitStrategyHandleProvider @Autowired constructor(
+    private val appSettings: AppSettings
+) : Provider<ApplicationExitHandler> {
+
+    override fun provide(): ApplicationExitHandler = when (appSettings.exitStrategy) {
+        ExitStrategy.LOG -> LogOnExit
+        ExitStrategy.EXCEPTION -> ExceptionOnError
+        ExitStrategy.DEBUG -> DebugOnExit
+    }
+}

--- a/src/main/kotlin/xyz/avalonxr/provider/Provider.kt
+++ b/src/main/kotlin/xyz/avalonxr/provider/Provider.kt
@@ -1,0 +1,20 @@
+package xyz.avalonxr.provider
+
+/**
+ * @author Atri
+ *
+ * A stereotype which describes a class which is meant to provide a value dependent on some form of external value. This
+ * can be used to map enum values used in configuration files to corresponding concrete logic classes. An example of
+ * this in action is seen in [ExitStrategyHandleProvider].
+ *
+ * @property T The concrete logic type we should expect the implementation to provide.
+ */
+interface Provider<T> {
+
+    /**
+     * Provides a value corresponding to the given provider type [T].
+     *
+     * @return An object matching the given provider type.
+     */
+    fun provide(): T
+}

--- a/src/main/kotlin/xyz/avalonxr/service/LifecycleService.kt
+++ b/src/main/kotlin/xyz/avalonxr/service/LifecycleService.kt
@@ -5,7 +5,8 @@ import org.springframework.boot.SpringApplication
 import org.springframework.context.ApplicationContext
 import org.springframework.stereotype.Service
 import xyz.avalonxr.enums.ExitCode
-import xyz.avalonxr.enums.ExitHandlerStrategy
+import xyz.avalonxr.enums.ExitStrategy
+import xyz.avalonxr.provider.ExitStrategyHandleProvider
 
 /**
  * @author Atri
@@ -20,11 +21,11 @@ import xyz.avalonxr.enums.ExitHandlerStrategy
 @Service
 class LifecycleService @Autowired constructor(
     private val context: ApplicationContext,
-    private val strategy: ExitHandlerStrategy
+    private val strategy: ExitStrategyHandleProvider
 ) {
 
     /**
-     * Shuts down the application and calls the provided [ExitHandlerStrategy].
+     * Shuts down the application and calls the provided [ExitStrategy].
      *
      * @param code The exit code to set our shutdown by.
      * @param extras Any values that we would like to include in our exit code's log message.
@@ -33,6 +34,6 @@ class LifecycleService @Autowired constructor(
         code: ExitCode = ExitCode.OK,
         vararg extras: Any?
     ): Nothing = SpringApplication
-        .exit(context, { strategy.handler.handleExit(code, *extras) })
+        .exit(context, { strategy.provide().handleExit(code, *extras) })
         .let { throw Exception("Exiting Application") } // Shouldn't reach this point
 }

--- a/src/test/kotlin/xyz/avalonxr/config/MockValidatorConfig.kt
+++ b/src/test/kotlin/xyz/avalonxr/config/MockValidatorConfig.kt
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.ActiveProfiles
-import xyz.avalonxr.enums.ExitHandlerStrategy
+import xyz.avalonxr.enums.ExitStrategy
 import xyz.avalonxr.validation.validator.MockValidator
 
 @Configuration
@@ -16,7 +16,7 @@ class MockValidatorConfig @Autowired constructor(
 ) {
 
     @Bean
-    fun exitStrategy(): ExitHandlerStrategy =
+    fun exitStrategy(): ExitStrategy =
         appSettings.exitStrategy
 
     @Bean

--- a/src/test/kotlin/xyz/avalonxr/enums/ExitStrategySpec.kt
+++ b/src/test/kotlin/xyz/avalonxr/enums/ExitStrategySpec.kt
@@ -12,20 +12,20 @@ import xyz.avalonxr.config.AppSettings
 @SpringBootTest
 @ActiveProfiles("test")
 @Import(AppSettings::class)
-class ExitHandlerStrategySpec(
-    private val exitHandlerStrategy: ExitHandlerStrategy
+class ExitStrategySpec(
+    private val exitHandlerStrategy: ExitStrategy
 ) : DescribeSpec({
 
     extensions(SpringTestExtension())
 
-    describe("ExitHandlerStrategy Tests") {
+    describe("ExitStrategy Tests") {
 
         it("Should provide an exit handler strategy") {
             exitHandlerStrategy.shouldNotBeNull()
         }
 
         it("Should have the correct strategy") {
-            exitHandlerStrategy shouldBe ExitHandlerStrategy.DEBUG
+            exitHandlerStrategy shouldBe ExitStrategy.DEBUG
         }
     }
 })

--- a/src/test/kotlin/xyz/avalonxr/provider/ExitStrategyHandleProviderSpec.kt
+++ b/src/test/kotlin/xyz/avalonxr/provider/ExitStrategyHandleProviderSpec.kt
@@ -1,0 +1,54 @@
+package xyz.avalonxr.provider
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import xyz.avalonxr.enums.ExitStrategy
+import xyz.avalonxr.handler.exit.DebugOnExit
+import xyz.avalonxr.handler.exit.ExceptionOnError
+import xyz.avalonxr.handler.exit.LogOnExit
+
+class ExitStrategyHandleProviderSpec : DescribeSpec({
+
+    fun makeSubject(
+        strategy: ExitStrategy = ExitStrategy.LOG
+    ): ExitStrategyHandleProvider = ExitStrategyHandleProvider(
+        mockk {
+            every { exitStrategy } returns strategy
+        }
+    )
+
+    describe("ExitStrategyHandleProvider Tests") {
+
+        describe("Provide") {
+
+            describe("An exit strategy is retrieved") {
+                val result = makeSubject()
+                    .provide()
+
+                it("Should return the correct strategy type") {
+                    result shouldBe LogOnExit
+                }
+            }
+
+            describe("When the exit strategy is set to EXCEPTION") {
+                val result = makeSubject(ExitStrategy.EXCEPTION)
+                    .provide()
+
+                it("Should return the correct strategy type") {
+                    result shouldBe ExceptionOnError
+                }
+            }
+
+            describe("When the exit strategy is set to DEBUG") {
+                val result = makeSubject(ExitStrategy.DEBUG)
+                    .provide()
+
+                it("Should return the correct strategy type") {
+                    result shouldBe DebugOnExit
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Apparently with the way Spring constructs enums, we cannot provide a constructor to it as that data cannot be resolved at runtime. To fix this, ExitStrategy has been converted to a plain enum class, and a provider class ExitStrategyHandleProvider has been added to handle mapping the data from the configuration.