### PR TITLE
feat: Introduce command validation logic

### DIFF
--- a/src/main/kotlin/xyz/avalonxr/data/error/ValidationError.kt
+++ b/src/main/kotlin/xyz/avalonxr/data/error/ValidationError.kt
@@ -1,0 +1,12 @@
+package xyz.avalonxr.data.error
+
+/**
+ * @author Atri
+ *
+ *  A grouping type derivative of [AvalonError] meant to contain error or success messages associated with validation.
+ */
+sealed class ValidationError(message: String) : AvalonError(message) {
+
+    class DuplicateCommandNames(names: Collection<String>) :
+        ValidationError("Command list contains duplicated names: $names")
+}

--- a/src/main/kotlin/xyz/avalonxr/service/command/CommandValidationService.kt
+++ b/src/main/kotlin/xyz/avalonxr/service/command/CommandValidationService.kt
@@ -1,0 +1,21 @@
+package xyz.avalonxr.service.command
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import xyz.avalonxr.data.error.ValidationError
+import xyz.avalonxr.models.discord.Command
+import xyz.avalonxr.validation.service.MultiValidationService
+import xyz.avalonxr.validation.validator.command.CommandValidator
+
+/**
+ * @author Atri
+ *
+ * A validation service that is intended to validate the integrity and structure of [Command] objects. This is necessary
+ * for us to perform ahead of pushing commands to Discord in order to ensure we do not send broken command definitions.
+ *
+ * @property validators All validators confirming to the type [CommandValidator]. This is provided to us by Spring.
+ */
+@Service
+class CommandValidationService @Autowired constructor(
+    override val validators: List<CommandValidator>
+) : MultiValidationService<Command, ValidationError, CommandValidator>

--- a/src/main/kotlin/xyz/avalonxr/validation/validator/command/CheckForDuplicates.kt
+++ b/src/main/kotlin/xyz/avalonxr/validation/validator/command/CheckForDuplicates.kt
@@ -1,0 +1,35 @@
+package xyz.avalonxr.validation.validator.command
+
+import org.springframework.stereotype.Component
+import xyz.avalonxr.data.error.ValidationError
+import xyz.avalonxr.models.discord.Command
+
+/**
+ * @author Atri
+ *
+ * A derivative of [CommandValidator] which checks if all commands in the provided command list have a unique command
+ * name. If the provided list does not conform to the constraints provided by this validator, a validation error for
+ * [ValidationError.DuplicateCommandNames] is returned. If no error is detected, then null is returned instead.
+ */
+@Component
+class CheckForDuplicates : CommandValidator {
+
+    override fun validate(values: List<Command>): ValidationError? {
+        val visited = mutableSetOf<String>()
+        val duplicates = mutableSetOf<String>()
+
+        for (value in values) {
+            val name = value.getCommandDescriptor().name()
+
+            if (name in visited) {
+                duplicates.add(name)
+            }
+
+            visited.add(name)
+        }
+
+        return ValidationError
+            .DuplicateCommandNames(duplicates)
+            .takeIf { duplicates.isNotEmpty() }
+    }
+}

--- a/src/main/kotlin/xyz/avalonxr/validation/validator/command/CommandValidator.kt
+++ b/src/main/kotlin/xyz/avalonxr/validation/validator/command/CommandValidator.kt
@@ -1,0 +1,16 @@
+package xyz.avalonxr.validation.validator.command
+
+import xyz.avalonxr.data.error.ValidationError
+import xyz.avalonxr.models.discord.Command
+import xyz.avalonxr.validation.validator.MultiValidator
+
+/**
+ * @author Atri
+ *
+ * A derivative of [MultiValidator] that acts as a collection type for command validators. These are used in determining
+ * whether the list of commands present in the application are uniform, such that we can quickly determine which command
+ * is meant to be called.
+ *
+ * @see CheckForDuplicates
+ */
+interface CommandValidator : MultiValidator<Command, ValidationError>


### PR DESCRIPTION
This is a small PR which introduces a bare-bones level of support for command validation. Later on this may be extended to provide other forms of validation, but for now this only includes CheckForDuplicates as the sole validation step.