### PR TITLE
feat: Add basic command service

### DIFF
--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -13,7 +13,14 @@ style:
     maxLineLength: 120
   TrailingWhitespace:
     active: true
+  ReturnCount:
+    active: false
+  UnusedPrivateMember:
+    active: false
 
+naming:
+  FunctionParameterNaming:
+    parameterPattern: _?[a-z][A-Za-z0-9]*
 exceptions:
   TooGenericExceptionThrown:
     active: false

--- a/src/main/kotlin/xyz/avalonxr/annotations/AvalonCommand.kt
+++ b/src/main/kotlin/xyz/avalonxr/annotations/AvalonCommand.kt
@@ -1,0 +1,15 @@
+package xyz.avalonxr.annotations
+
+import org.springframework.stereotype.Component
+import xyz.avalonxr.annotations.dsl.CommandDsl
+
+/**
+ * @author Atri
+ *
+ * Describes a component stereotype relating to custom discord slash commands. Marking a class with this implicitly
+ * scopes it as a subtype of the [Component] stereotype, which should allow spring to retrieve the value.
+ */
+@Component
+@CommandDsl
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AvalonCommand

--- a/src/main/kotlin/xyz/avalonxr/data/CommandResult.kt
+++ b/src/main/kotlin/xyz/avalonxr/data/CommandResult.kt
@@ -3,17 +3,17 @@ package xyz.avalonxr.data
 import xyz.avalonxr.data.error.AvalonError
 
 class CommandResult private constructor(
-    val error: AvalonError? = null
-) {
-    fun isError(): Boolean =
-        error != null
+    error: AvalonError? = null,
+) : Payload<AvalonError>(error) {
+
+    fun isError(): Boolean = data != null
 
     companion object {
 
-        fun ofSuccess(): CommandResult =
+        fun success(): CommandResult =
             CommandResult()
 
-        fun ofFailure(
+        fun failure(
             error: AvalonError
         ) = CommandResult(error)
     }

--- a/src/main/kotlin/xyz/avalonxr/data/Payload.kt
+++ b/src/main/kotlin/xyz/avalonxr/data/Payload.kt
@@ -1,0 +1,5 @@
+package xyz.avalonxr.data
+
+open class Payload<T>(
+    val data: T? = null
+)

--- a/src/main/kotlin/xyz/avalonxr/data/error/CommandError.kt
+++ b/src/main/kotlin/xyz/avalonxr/data/error/CommandError.kt
@@ -1,0 +1,6 @@
+package xyz.avalonxr.data.error
+
+sealed class CommandError(message: String) : AvalonError(message) {
+
+    class CommandNotFound(commandName: String) : CommandError("Could not find command matching name: $commandName")
+}

--- a/src/main/kotlin/xyz/avalonxr/service/command/CommandService.kt
+++ b/src/main/kotlin/xyz/avalonxr/service/command/CommandService.kt
@@ -1,0 +1,81 @@
+package xyz.avalonxr.service.command
+
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.core.`object`.command.ApplicationCommandInteractionOption
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.event.ApplicationStartedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Service
+import xyz.avalonxr.data.CommandResult
+import xyz.avalonxr.data.OptionStore
+import xyz.avalonxr.data.error.CommandError
+import xyz.avalonxr.enums.ExitCode
+import xyz.avalonxr.models.discord.Command
+import xyz.avalonxr.service.LifecycleService
+
+@Service
+class CommandService @Autowired constructor(
+    private val commands: List<Command>,
+    private val commandValidatorService: CommandValidationService,
+    private val lifecycleService: LifecycleService,
+) {
+    private val commandCache: Map<String, Command> by lazy { initialize() }
+
+    fun processCommand(event: ChatInputInteractionEvent): CommandResult {
+        // Check that the cache has been initialized before we continue
+        val commandName = event.commandName
+        // Make sure the user sends us a valid command
+        // Todo: We likely should have this divert to a non-command default handler
+        val command = commandCache[commandName]
+            ?: return CommandResult.failure(CommandError.CommandNotFound(commandName))
+        // Collect command context data, TODO we may want to change this to encapsulate things in a data class
+        val user = event.interaction.user
+        val guildId = event.interaction.guildId.orElse(null)
+        val options = event.options.toOptionStore()
+        // Run command logic with context
+        logger.info("Command '$commandName' executed by ${user.username}")
+        return command.processCommand(event, user, guildId, options)
+    }
+
+    fun findCommandByName(name: String): Command? = commandCache[name]
+
+    fun findCommandsByNames(names: Collection<String>): List<Command> = commandCache
+        .filter { (name) -> name in names }
+        .values
+        .toList()
+
+    @EventListener(ApplicationStartedEvent::class)
+    fun getAllCommands(): List<Command> = commandCache.values.toList()
+
+    // While this likely isn't an immediate issue, I don't think this currently
+    // handles subcommands or groups correctly. We should evaluate this later on.
+    private fun List<ApplicationCommandInteractionOption>.toOptionStore(): OptionStore = this
+        .map { it.name to it.value }
+        .toTypedArray()
+        .let { OptionStore(*it) }
+
+    private fun initialize(): Map<String, Command> {
+        logger.info("Starting command service...")
+        // Short-circuit if no commands are present
+        if (commands.isEmpty()) {
+            logger.info("No commands in registry! Command service ready!")
+            return emptyMap()
+        }
+        // Check for validation errors, shut down with error log if any exist
+        val errors = commandValidatorService.validate(commands)
+        if (errors.isNotEmpty()) {
+            lifecycleService.shutdown(ExitCode.INITIALIZATION_FAILURE, this::class.java, errors)
+        }
+        // Cache validated commands into list
+        return commands
+            .associateBy { it.getCommandDescriptor().name() }
+            .also { logger.info("Command service ready! Registered commands: ${it.keys}") }
+    }
+
+    companion object {
+
+        private val logger = LoggerFactory
+            .getLogger(CommandService::class.java)
+    }
+}

--- a/src/test/kotlin/xyz/avalonxr/fixtures/discord/ApplicationCommandInteractionOptionFixture.kt
+++ b/src/test/kotlin/xyz/avalonxr/fixtures/discord/ApplicationCommandInteractionOptionFixture.kt
@@ -1,0 +1,19 @@
+package xyz.avalonxr.fixtures.discord
+
+import discord4j.core.`object`.command.ApplicationCommandInteractionOption
+import discord4j.core.`object`.command.ApplicationCommandInteractionOptionValue
+import io.mockk.every
+import io.mockk.mockk
+import java.util.Optional
+
+@Suppress("LocalVariableName")
+object ApplicationCommandInteractionOptionFixture {
+
+    fun make(
+        _name: String = "Baz",
+        _value: ApplicationCommandInteractionOptionValue? = ApplicationCommandInteractionOptionValueFixture.make()
+    ): ApplicationCommandInteractionOption = mockk {
+        every { name } returns _name
+        every { value } returns Optional.ofNullable(_value)
+    }
+}

--- a/src/test/kotlin/xyz/avalonxr/fixtures/discord/ApplicationCommandInteractionOptionValueFixture.kt
+++ b/src/test/kotlin/xyz/avalonxr/fixtures/discord/ApplicationCommandInteractionOptionValueFixture.kt
@@ -1,0 +1,21 @@
+package xyz.avalonxr.fixtures.discord
+
+import discord4j.core.`object`.command.ApplicationCommandInteractionOptionValue
+import io.mockk.mockk
+import xyz.avalonxr.dsl.discord.OptionType
+
+@Suppress("LocalVariableName")
+object ApplicationCommandInteractionOptionValueFixture {
+
+    fun make(
+        _guildId: Long? = 2931823482343243242,
+        _optionType: OptionType = OptionType.STRING,
+        _value: String = "FooBarBaz"
+    ): ApplicationCommandInteractionOptionValue = ApplicationCommandInteractionOptionValue(
+        mockk(),
+        _guildId,
+        _optionType.value,
+        _value,
+        mockk()
+    )
+}

--- a/src/test/kotlin/xyz/avalonxr/fixtures/discord/ChatInputInteractionEventFixture.kt
+++ b/src/test/kotlin/xyz/avalonxr/fixtures/discord/ChatInputInteractionEventFixture.kt
@@ -1,0 +1,23 @@
+package xyz.avalonxr.fixtures.discord
+
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.core.`object`.command.ApplicationCommandInteractionOption
+import discord4j.core.`object`.command.Interaction
+import io.mockk.every
+import io.mockk.mockk
+
+@Suppress("LocalVariableName")
+object ChatInputInteractionEventFixture {
+
+    fun make(
+        _commandName: String = "foo",
+        _interaction: Interaction = InteractionFixture.make(),
+        _optionsList: List<ApplicationCommandInteractionOption> = listOf(
+            ApplicationCommandInteractionOptionFixture.make()
+        )
+    ): ChatInputInteractionEvent = mockk {
+        every { commandName } returns _commandName
+        every { interaction } returns _interaction
+        every { options } returns _optionsList
+    }
+}

--- a/src/test/kotlin/xyz/avalonxr/fixtures/discord/InteractionFixture.kt
+++ b/src/test/kotlin/xyz/avalonxr/fixtures/discord/InteractionFixture.kt
@@ -1,0 +1,22 @@
+package xyz.avalonxr.fixtures.discord
+
+import discord4j.common.util.Snowflake
+import discord4j.core.`object`.command.Interaction
+import discord4j.core.`object`.entity.User
+import io.mockk.every
+import io.mockk.mockk
+import java.util.*
+
+@Suppress("LocalVariableName")
+object InteractionFixture {
+
+    fun make(
+        _user: User = UserFixture.make(),
+        _guildId: Long? = 329438234823423423,
+    ): Interaction = mockk {
+        every { user } returns _user
+        every { guildId } returns _guildId
+            ?.let(Snowflake::of)
+            .let { Optional.ofNullable(it) }
+    }
+}

--- a/src/test/kotlin/xyz/avalonxr/fixtures/discord/UserFixture.kt
+++ b/src/test/kotlin/xyz/avalonxr/fixtures/discord/UserFixture.kt
@@ -1,0 +1,15 @@
+package xyz.avalonxr.fixtures.discord
+
+import discord4j.core.`object`.entity.User
+import io.mockk.every
+import io.mockk.mockk
+
+@Suppress("LocalVariableName")
+object UserFixture {
+
+    fun make(
+        _username: String = "FooBar"
+    ): User = mockk {
+        every { username } returns _username
+    }
+}

--- a/src/test/kotlin/xyz/avalonxr/models/discord/TestCommand.kt
+++ b/src/test/kotlin/xyz/avalonxr/models/discord/TestCommand.kt
@@ -1,0 +1,21 @@
+package xyz.avalonxr.models.discord
+
+import discord4j.common.util.Snowflake
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.core.`object`.entity.User
+import discord4j.discordjson.json.ApplicationCommandRequest
+import xyz.avalonxr.data.CommandResult
+import xyz.avalonxr.data.OptionStore
+import xyz.avalonxr.dsl.discord.command
+
+object TestCommand : Command {
+
+    override fun getCommandDescriptor(): ApplicationCommandRequest = command("foo")
+
+    override fun processCommand(
+        source: ChatInputInteractionEvent,
+        user: User,
+        guildId: Snowflake?,
+        options: OptionStore
+    ): CommandResult = CommandResult.success()
+}

--- a/src/test/kotlin/xyz/avalonxr/service/command/CommandServiceSpec.kt
+++ b/src/test/kotlin/xyz/avalonxr/service/command/CommandServiceSpec.kt
@@ -1,0 +1,204 @@
+package xyz.avalonxr.service.command
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import xyz.avalonxr.data.CommandResult
+import xyz.avalonxr.data.error.CommandError
+import xyz.avalonxr.data.error.ValidationError
+import xyz.avalonxr.fixtures.discord.ChatInputInteractionEventFixture
+import xyz.avalonxr.models.discord.Command
+import xyz.avalonxr.models.discord.TestCommand
+import xyz.avalonxr.service.LifecycleService
+
+class CommandServiceSpec : DescribeSpec({
+
+    isolationMode = IsolationMode.InstancePerTest
+
+    describe("CommandService Tests") {
+        val commands = mutableListOf(
+            TestCommand
+        )
+        val validatorService = mockk<CommandValidationService> {
+            every { validate(any()) } returns emptyList()
+        }
+        val lifecycleService = mockk<LifecycleService> {
+            every { shutdown(any(), *anyVararg()) } throws RuntimeException("Exited")
+        }
+        val event = ChatInputInteractionEventFixture.make()
+        val failEvent = ChatInputInteractionEventFixture.make(
+            _commandName = "bar"
+        )
+        val service = CommandService(
+            commands,
+            validatorService,
+            lifecycleService
+        )
+
+        describe("processCommand") {
+            lateinit var result: CommandResult
+
+            describe("A command is executed successfully") {
+                beforeTest {
+                    result = service.processCommand(event)
+                }
+
+                it("Should be a success result") {
+                    result.isError().shouldBeFalse()
+                }
+            }
+
+            describe("When the command validation service returns an error") {
+                beforeTest {
+                    every { validatorService.validate(any()) } returns listOf(
+                        ValidationError.DuplicateCommandNames(listOf("FOO"))
+                    )
+                    runCatching {
+                        result = service.processCommand(event)
+                    }
+                }
+
+                it("Should call lifecycle service shutdown") {
+                    verify(exactly = 1) {
+                        lifecycleService.shutdown(any(), *anyVararg())
+                    }
+                }
+            }
+
+            describe("When the requested command does not exist") {
+                beforeTest {
+                    result = service.processCommand(failEvent)
+                }
+
+                it("Should be a failure result") {
+                    result.isError().shouldBeTrue()
+                }
+
+                it("Should have correct error message") {
+                    result.data.shouldBeInstanceOf<CommandError.CommandNotFound>()
+                }
+            }
+        }
+
+        describe("findCommandByName") {
+            var result: Command? = null
+
+            describe("A command is retrieved successfully") {
+                beforeTest {
+                    result = service.findCommandByName("foo")
+                }
+
+                it("Should be a success result") {
+                    result?.getCommandDescriptor()?.name() shouldBe "foo"
+                }
+            }
+
+            describe("When the command validation service returns an error") {
+                beforeTest {
+                    every { validatorService.validate(any()) } returns listOf(
+                        ValidationError.DuplicateCommandNames(listOf("FOO"))
+                    )
+                    runCatching {
+                        result = service.findCommandByName("foo")
+                    }
+                }
+
+                it("Should call lifecycle service shutdown") {
+                    verify(exactly = 1) {
+                        lifecycleService.shutdown(any(), *anyVararg())
+                    }
+                }
+            }
+
+            describe("When the requested command does not exist") {
+                beforeTest {
+                    result = service.findCommandByName("bar")
+                }
+
+                it("Should return null") {
+                    result.shouldBeNull()
+                }
+            }
+        }
+
+        describe("findCommandsByNames") {
+            lateinit var result: List<Command>
+
+            describe("A list of commands is successfully retrieved") {
+                beforeTest {
+                    result = service.findCommandsByNames(listOf("foo"))
+                }
+
+                it("Should be a success result") {
+                    result[0].getCommandDescriptor().name() shouldBe "foo"
+                }
+            }
+
+            describe("When the command validation service returns an error") {
+                beforeTest {
+                    every { validatorService.validate(any()) } returns listOf(
+                        ValidationError.DuplicateCommandNames(listOf("foo"))
+                    )
+                    runCatching {
+                        result = service.findCommandsByNames(listOf("foo"))
+                    }
+                }
+
+                it("Should call lifecycle service shutdown") {
+                    verify(exactly = 1) {
+                        lifecycleService.shutdown(any(), *anyVararg())
+                    }
+                }
+            }
+
+            describe("When none of the requested commands exist") {
+                beforeTest {
+                    result = service.findCommandsByNames(listOf("bar"))
+                }
+
+                it("Should return an empty list") {
+                    result.shouldBeEmpty()
+                }
+            }
+        }
+
+        describe("getAllCommands") {
+            lateinit var result: List<Command>
+
+            describe("All cached commands are successfully retrieved") {
+                beforeTest {
+                    result = service.getAllCommands()
+                }
+
+                it("Should be a success result") {
+                    result[0].getCommandDescriptor().name() shouldBe "foo"
+                }
+            }
+
+            describe("When the command validation service returns an error") {
+                beforeTest {
+                    every { validatorService.validate(any()) } returns listOf(
+                        ValidationError.DuplicateCommandNames(listOf("foo"))
+                    )
+                    runCatching {
+                        result = service.getAllCommands()
+                    }
+                }
+
+                it("Should call lifecycle service shutdown") {
+                    verify(exactly = 1) {
+                        lifecycleService.shutdown(any(), *anyVararg())
+                    }
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
The purpose of this class is primarily to validate and cache commands present in our application in a lazy fashion. This also provides logic for routing and processing a command via an event function. This will be connected up via a command binding service later.

Fixes: #4