### PR TITLE
chore: Allow Discord token to resolve via environment variables

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,4 +7,4 @@ avalon:
   exit:
     strategy: LOG
 discord:
-  token: # TOKEN GOES HERE
+  token: ${discordToken}


### PR DESCRIPTION
This will allow us to store the token in a place outside our configuration files where it may accidentally be committed.