### PR TITLE
feat: Add support for JPA entities and repositories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
-import org.jetbrains.kotlin.config.JvmTarget
 
 plugins {
     alias(libs.plugins.boot)
@@ -8,6 +7,7 @@ plugins {
     alias(libs.plugins.detekt)
     kotlin("jvm") version libs.versions.kotlin
     kotlin("plugin.spring") version libs.versions.kotlin
+    kotlin("plugin.jpa") version libs.versions.kotlin
 }
 
 group = "xyz.avalonxr"
@@ -28,6 +28,7 @@ dependencies {
     implementation(libs.discord)
     implementation(libs.bundles.spring)
 
+    runtimeOnly(libs.h2.database)
     // Unit testing support
     testImplementation(libs.bundles.testing)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,9 @@ discord = { module = "com.discord4j:discord4j-core", version.ref = "discord" }
 spring-boot = { module = "org.springframework.boot:spring-boot", version.ref = "spring-boot" }
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
+# Runtime
+h2-database = { module = "com.h2database:h2" }
 # Test dependencies
 kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest-core" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest-core" }
@@ -36,6 +39,7 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 spring = [
     "spring-boot",
     "spring-boot-starter",
+    "spring-boot-starter-data-jpa",
 ]
 
 testing = [
@@ -43,5 +47,5 @@ testing = [
     "kotest-assertions",
     "kotest-spring",
     "mockk",
-    "spring-boot-starter-test"
+    "spring-boot-starter-test",
 ]

--- a/src/main/kotlin/xyz/avalonxr/data/entity/WelcomeMessage.kt
+++ b/src/main/kotlin/xyz/avalonxr/data/entity/WelcomeMessage.kt
@@ -1,0 +1,52 @@
+package xyz.avalonxr.data.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.sql.Timestamp
+
+/**
+ * @author Atri
+ *
+ * Describes the entity used for storing welcome messages related to user join events. This will later be used to send a
+ * pre-configured message to the user when they join a guild.
+ */
+@Entity
+@Table(name = "welcome_message")
+class WelcomeMessage(
+
+    /**
+     * Maps to a Discord guild's ID.
+     */
+    @Column(name = "guild_id", insertable = true, updatable = true, unique = true, nullable = false)
+    var guildId: Long,
+
+    /**
+     * Maps to a channel ID for a channel within a Discord guild.
+     */
+    @Column(name = "channel_id", insertable = true, updatable = true, nullable = false)
+    var channelId: Long,
+
+    /**
+     * The message we want to send upon user join. This field may contain un-formatted text that will need to be parsed
+     * at runtime before sending to the user.
+     */
+    @Column(name = "message", insertable = true, updatable = true, nullable = false)
+    var message: String,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "welcome_message_id", insertable = false, updatable = false, unique = true)
+    val welcomeMessageId: Long? = null
+
+    @CreationTimestamp
+    val createdTimestamp: Timestamp? = null
+
+    @UpdateTimestamp
+    val updateTimestamp: Timestamp? = null
+}

--- a/src/main/kotlin/xyz/avalonxr/repository/WelcomeMessageRepository.kt
+++ b/src/main/kotlin/xyz/avalonxr/repository/WelcomeMessageRepository.kt
@@ -1,0 +1,22 @@
+package xyz.avalonxr.repository
+
+import org.springframework.data.repository.CrudRepository
+import xyz.avalonxr.data.entity.WelcomeMessage
+import java.util.Optional
+
+/**
+ * @author Atri
+ *
+ * A repository for managing [WelcomeMessage] entities in our database. This provides functionality for retrieving any
+ */
+interface WelcomeMessageRepository : CrudRepository<WelcomeMessage, Long> {
+
+    /**
+     * Retrieves entities by guild id.
+     *
+     * @param guildId The guild id we want to retrieve.
+     *
+     * @return An entry matching the given [guildId] or empty if not present in the database.
+     */
+    fun findByGuildId(guildId: Long): Optional<WelcomeMessage>
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,17 @@ spring:
     active: prod
   main:
     keep-alive: true
+  jpa:
+    database: Avalon
+    show-sql: false
+    hibernate:
+      ddl-auto: update
+  datasource:
+    platform: postgres
+    url: ${dbAddress}
+    username: ${dbUsername}
+    password: ${dbPassword}
+    driverClassName: org.postgresql.Driver
 avalon:
   exit:
     strategy: LOG

--- a/src/main/resources/sql/test/welcome_message_test.sql
+++ b/src/main/resources/sql/test/welcome_message_test.sql
@@ -1,0 +1,5 @@
+delete from welcome_message
+where welcome_message_id in (198123123);
+
+insert into welcome_message (welcome_message_id, guild_id, channel_id, message)
+values (198123123, 1076316414421499924, 1125462364452565003, 'Hello world!');

--- a/src/test/kotlin/xyz/avalonxr/repository/WelcomeMessageRepositorySpec.kt
+++ b/src/test/kotlin/xyz/avalonxr/repository/WelcomeMessageRepositorySpec.kt
@@ -1,0 +1,93 @@
+package xyz.avalonxr.repository
+
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.matchers.optional.shouldBeEmpty
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.jdbc.Sql
+import xyz.avalonxr.data.entity.WelcomeMessage
+import java.util.*
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Sql("classpath:sql/test/welcome_message_test.sql")
+class WelcomeMessageRepositorySpec @Autowired constructor(
+    private val repository: WelcomeMessageRepository,
+) : DescribeSpec({
+
+    extensions(SpringTestExtension())
+
+    describe("WelcomeMessageRepository Tests") {
+
+        describe("findById") {
+            lateinit var result: Optional<WelcomeMessage>
+
+            describe("A column is retrieved successfully") {
+                beforeTest {
+                    result = repository.findById(198123123)
+                }
+
+                it("Should have the correct message") {
+                    result.shouldBePresent {
+                        message shouldBe "Hello world!"
+                    }
+                }
+            }
+        }
+
+        describe("findByGuildId") {
+            lateinit var result: Optional<WelcomeMessage>
+
+            describe("A column is retrieved successfully") {
+                beforeTest {
+                    result = repository.findByGuildId(1076316414421499924)
+                }
+
+                it("Should have the correct message") {
+                    result.shouldBePresent {
+                        message shouldBe "Hello world!"
+                    }
+                }
+            }
+
+            describe("When an guild id does not exist in the table") {
+                result = repository.findByGuildId(98242)
+
+                it("Should not return a result") {
+                    result.shouldBeEmpty()
+                }
+            }
+        }
+
+        describe("save") {
+            lateinit var result: Optional<WelcomeMessage>
+
+            describe("A column is saved to the database successfully") {
+                beforeTest {
+                    repository.save(WelcomeMessage(9123912312, 21938123921, "Test!"))
+                    result = repository.findByGuildId(9123912312)
+                }
+
+                it("Should have the correct message") {
+                    result.shouldBePresent {
+                        message shouldBe "Test!"
+                    }
+                }
+            }
+
+            describe("When an entry is saved over an existing entry") {
+
+                it("Should result in a failure") {
+                    shouldThrowAny {
+                        repository.save(WelcomeMessage(9123912312, 21938123921, "Test!"))
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,5 +1,7 @@
 spring:
   profiles:
     active: test
+  jpa:
+    show-sql: true
 avalon:
   exit.strategy: DEBUG


### PR DESCRIPTION
This currently implements things primarily under the h2 database, later on this will need to be configured to use an external Postgres instance, though it does execute Postgres SQL scripts internally as the database flavor.

Fixes #16