### PR TITLE
fix: Add better support for subcommands

### DIFF
--- a/src/main/kotlin/xyz/avalonxr/dsl/discord/CommandDsl.kt
+++ b/src/main/kotlin/xyz/avalonxr/dsl/discord/CommandDsl.kt
@@ -16,7 +16,7 @@ typealias OptionDataBuilder =
 @CommandDsl
 fun command(
     name: String,
-    builder: CommandRequestBuilder.() -> Unit = {}
+    builder: CommandRequestBuilder.() -> Unit = {},
 ): ApplicationCommandRequest = ApplicationCommandRequest
     .builder()
     .name(name)
@@ -26,7 +26,7 @@ fun command(
 @CommandDsl
 fun CommandRequestBuilder.option(
     type: OptionType,
-    builder: OptionDataBuilder.() -> Unit
+    builder: OptionDataBuilder.() -> Unit,
 ): CommandRequestBuilder = ApplicationCommandOptionData
     .builder()
     .type(type.value)
@@ -36,9 +36,19 @@ fun CommandRequestBuilder.option(
     .let(::addOption)
 
 @CommandDsl
+fun CommandRequestBuilder.subCommand(
+    builder: OptionDataBuilder.() -> Unit,
+): CommandRequestBuilder = ApplicationCommandOptionData
+    .builder()
+    .type(OptionType.SUB_COMMAND.value)
+    .also(builder)
+    .build()
+    .let(::addOption)
+
+@CommandDsl
 fun OptionDataBuilder.option(
     type: OptionType,
-    builder: OptionDataBuilder.() -> Unit
+    builder: OptionDataBuilder.() -> Unit,
 ): OptionDataBuilder = ApplicationCommandOptionData
     .builder()
     .type(type.value)
@@ -97,5 +107,5 @@ enum class OptionType(val value: Int) {
 
     NUMBER(10),
 
-    ATTACHMENT(11)
+    ATTACHMENT(11),
 }

--- a/src/main/kotlin/xyz/avalonxr/service/command/CommandService.kt
+++ b/src/main/kotlin/xyz/avalonxr/service/command/CommandService.kt
@@ -1,20 +1,17 @@
 package xyz.avalonxr.service.command
 
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
-import discord4j.core.`object`.command.ApplicationCommandInteractionOption
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import xyz.avalonxr.data.CommandResult
 import xyz.avalonxr.data.OptionStore
-import xyz.avalonxr.data.OptionValue
 import xyz.avalonxr.data.error.CommonError
 import xyz.avalonxr.enums.CommandScope
 import xyz.avalonxr.enums.ExitCode
 import xyz.avalonxr.handler.command.DefaultCommandHandler
 import xyz.avalonxr.models.discord.Command
 import xyz.avalonxr.service.LifecycleService
-import kotlin.jvm.optionals.getOrNull
 
 @Service
 class CommandService @Autowired constructor(
@@ -29,11 +26,10 @@ class CommandService @Autowired constructor(
         // Check that the cache has been initialized before we continue
         val commandName = event.commandName
         // Make sure the user sends us a valid command
-        // Todo: We likely should have this divert to a non-command default handler
         val command = commandCache[commandName]
             ?: return defaultCommandHandler.commandNotFound(event, commandName)
         // Collect command option data
-        val options = event.options.toOptionStore()
+        val options = OptionStore.toOptionStore(event.options)
         // Run command logic with context
         logger.info("Command '$commandName' executed by ${event.interaction.user.username}")
         return runCatching { command.processCommand(event, options) }
@@ -57,18 +53,6 @@ class CommandService @Autowired constructor(
 
     fun hasGuildCommand(name: String): Boolean = commandCache[name]
         ?.takeIf { it.getBinding().scope == CommandScope.GUILD } != null
-
-    // While this likely isn't an immediate issue, I don't think this currently
-    // handles subcommands or groups correctly. We should evaluate this later on.
-    private fun List<ApplicationCommandInteractionOption>.toOptionStore(): OptionStore = this
-        .mapNotNull(::processToPair)
-        .toTypedArray()
-        .let { OptionStore(*it) }
-
-    private fun processToPair(value: ApplicationCommandInteractionOption): Pair<String, OptionValue>? = value
-        .value
-        .getOrNull()
-        ?.let { value.name to OptionValue(it, value.type) }
 
     private fun initialize(): Map<String, Command> {
         logger.info("Starting command service...")


### PR DESCRIPTION
This should improve parsing for options in OptionStore, as well as allow for easier description of subcommands in command bindings.

Fixes #40