### PR TITLE
feat: Add welcome message configuration command and subcommands

### DIFF
--- a/src/main/kotlin/xyz/avalonxr/command/WelcomeCommand.kt
+++ b/src/main/kotlin/xyz/avalonxr/command/WelcomeCommand.kt
@@ -1,0 +1,138 @@
+package xyz.avalonxr.command
+
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.core.`object`.entity.channel.TextChannel
+import org.springframework.beans.factory.annotation.Autowired
+import xyz.avalonxr.annotations.AvalonCommand
+import xyz.avalonxr.data.CommandResult
+import xyz.avalonxr.data.OptionStore
+import xyz.avalonxr.data.ValidatedOptional
+import xyz.avalonxr.data.command.CommandBinding
+import xyz.avalonxr.data.entity.WelcomeMessage
+import xyz.avalonxr.data.error.CommandError
+import xyz.avalonxr.dsl.discord.OptionType
+import xyz.avalonxr.dsl.discord.command
+import xyz.avalonxr.dsl.discord.option
+import xyz.avalonxr.dsl.discord.optional
+import xyz.avalonxr.dsl.discord.subCommand
+import xyz.avalonxr.enums.CommandScope
+import xyz.avalonxr.models.discord.Command
+import xyz.avalonxr.repository.WelcomeMessageRepository
+import xyz.avalonxr.service.FormatService
+import xyz.avalonxr.utils.getGuildChannelById
+import xyz.avalonxr.utils.guildIdAsLong
+import xyz.avalonxr.utils.sendReply
+import kotlin.jvm.optionals.getOrDefault
+import kotlin.jvm.optionals.getOrNull
+
+@AvalonCommand
+class WelcomeCommand @Autowired constructor(
+    private val messageRepository: WelcomeMessageRepository,
+    private val formatService: FormatService,
+) : Command {
+
+    override fun getBinding(): CommandBinding = CommandBinding(
+        command("welcome") {
+            description("Welcome command")
+
+            subCommand {
+                name("set")
+                description("Configure welcome message")
+
+                option(OptionType.STRING) {
+                    name("message")
+                    description("Welcome Message")
+                }
+
+                option(OptionType.CHANNEL) {
+                    name("channel")
+                    description("Welcome Channel")
+                    optional()
+                }
+            }
+
+            subCommand {
+                name("preview")
+                description("Preview welcome message")
+
+                option(OptionType.BOOLEAN) {
+                    name("formatted")
+                    description("Preview formatted or un-formatted message")
+                    optional()
+                }
+            }
+        },
+        CommandScope.GUILD
+    )
+
+    override fun processCommand(
+        source: ChatInputInteractionEvent,
+        options: OptionStore
+    ): CommandResult {
+        return when (options.subCommand) {
+            "set" -> setSubcommand(source, options)
+            "preview" -> previewSubcommand(source, options)
+            else ->
+                CommandError
+                    .InvalidSubcommand("set", "preview")
+                    .let(CommandResult::failure)
+        }
+    }
+
+    private fun setSubcommand(
+        source: ChatInputInteractionEvent,
+        options: OptionStore
+    ): CommandResult {
+        val guildId = source.guildIdAsLong()
+            ?: return CommandResult.failure(CommandError.CommandNotFromGuild)
+        val defaultChannel = source.interaction.channel
+            .block()
+        val channel = when (val channelOption = options.findChannel<TextChannel>("channel")) {
+            is ValidatedOptional.Empty -> defaultChannel
+            is ValidatedOptional.Invalid -> return CommandResult.failure(CommandError.IncorrectChannelType)
+            is ValidatedOptional.Valid -> channelOption.data
+        }
+        val channelName = channel.mention
+        val message = options
+            .getOrDefault<String>("message", "Welcome!")
+        val welcomeMessage = messageRepository
+            .findByGuildId(guildId)
+            .getOrDefault(WelcomeMessage(guildId, channel.id.asLong(), message))
+
+        welcomeMessage.message = message
+        welcomeMessage.channelId = channel.id.asLong()
+        messageRepository.save(welcomeMessage)
+
+        source.sendReply("Configured welcome message in $channelName")
+
+        return CommandResult.success()
+    }
+
+    private fun previewSubcommand(
+        source: ChatInputInteractionEvent,
+        options: OptionStore
+    ): CommandResult {
+        val formatted = options
+            .getOrDefault<Boolean>("formatted", false)
+        val guildId = source.guildIdAsLong()
+            ?: return CommandResult.failure(CommandError.CommandNotFromGuild)
+        val welcomeMessage = messageRepository
+            .findByGuildId(guildId)
+            .getOrNull()
+        val content = welcomeMessage
+            ?.message
+            ?: "No welcome message configured."
+        val channelName = source
+            .getGuildChannelById(welcomeMessage?.channelId)
+            ?.mention
+        val message = when (formatted) {
+            true -> formatService.formatWithContext(source, content)
+            else -> content
+        }
+        val template = "$message in channel: $channelName"
+
+        source.sendReply(template)
+
+        return CommandResult.success()
+    }
+}

--- a/src/main/kotlin/xyz/avalonxr/data/error/CommandError.kt
+++ b/src/main/kotlin/xyz/avalonxr/data/error/CommandError.kt
@@ -5,4 +5,11 @@ sealed class CommandError(message: String) : AvalonError(message) {
     class CommandNotFound(commandName: String) : CommandError("Could not find command matching name: $commandName")
 
     class CommandFailed(commandName: String) : CommandError("Command $commandName failed to execute!")
+
+    data object CommandNotFromGuild : CommandError("Command must be sent from a guild!")
+
+    data object IncorrectChannelType : CommandError("Incorrect channel type!")
+
+    class InvalidSubcommand(vararg subcommands: String) :
+        CommandError("Subcommand not valid! Please specify command from list: $subcommands")
 }

--- a/src/main/kotlin/xyz/avalonxr/service/FormatService.kt
+++ b/src/main/kotlin/xyz/avalonxr/service/FormatService.kt
@@ -32,7 +32,7 @@ class FormatService @Autowired constructor(
         var current = input
         formatters
             .forEach { current = it.formatWithContext(event, current) }
-        return input
+        return current
     }
 
     companion object {


### PR DESCRIPTION
Added a command for configuring the welcome message with subcommands "set" to set the message and "preview" to preview the message, either formatted or unformatted.