### PR TITLE
chore: Introduce FormatContext class to encapsulate formatting data

### DIFF
--- a/src/main/kotlin/xyz/avalonxr/command/WelcomeCommand.kt
+++ b/src/main/kotlin/xyz/avalonxr/command/WelcomeCommand.kt
@@ -130,7 +130,7 @@ class WelcomeCommand @Autowired constructor(
             .getGuildChannelById(welcomeMessage?.channelId)
             ?.mention
         val message = when (formatted) {
-            true -> formatService.formatWithContext(source, content)
+            true -> formatService.formatForCommand(source, content)
             else -> content
         }
         val template = "'$message' (in channel: $channelName)"

--- a/src/main/kotlin/xyz/avalonxr/data/format/ChannelMentionFormatter.kt
+++ b/src/main/kotlin/xyz/avalonxr/data/format/ChannelMentionFormatter.kt
@@ -1,6 +1,6 @@
 package xyz.avalonxr.data.format
 
-import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.core.`object`.entity.channel.Channel
 import org.springframework.stereotype.Component
 import xyz.avalonxr.models.discord.DiscordStringFormatter
 
@@ -12,11 +12,12 @@ import xyz.avalonxr.models.discord.DiscordStringFormatter
 @Component
 class ChannelMentionFormatter : DiscordStringFormatter {
 
-    override fun formatWithContext(event: ChatInputInteractionEvent, input: String): String {
-        val channel = event.interaction.channel
+    override fun formatWithContext(context: FormatContext, input: String): String {
+        val channel = context
+            .channel
+            .map(Channel::getMention)
             .block()
-            ?.mention
-            ?: "Unknown"
+            ?: "[Invalid channel]"
 
         return input
             .replace("\${channel}", channel)

--- a/src/main/kotlin/xyz/avalonxr/data/format/FormatContext.kt
+++ b/src/main/kotlin/xyz/avalonxr/data/format/FormatContext.kt
@@ -1,0 +1,26 @@
+package xyz.avalonxr.data.format
+
+import discord4j.core.`object`.entity.Guild
+import discord4j.core.`object`.entity.Member
+import discord4j.core.`object`.entity.User
+import discord4j.core.`object`.entity.channel.Channel
+import reactor.core.publisher.Mono
+
+/**
+ * @author Atri
+ *
+ * This object encapsulates any items that may be associated with a given message context. This functions effectively
+ * as a wrapper to provide bindings to functions which may or may not provide the necessary data for a formatting step.
+ * To ensure performance, objects are provided in [Mono] boxing to ensure data is only retrieved as required.
+ *
+ * @property guild The originating guild associated with the action or event.
+ * @property channel The originating channel associated with the action or event.
+ * @property user The guild member data associated to the given [user].
+ * @property user The user who this context relates to.
+ */
+data class FormatContext(
+    val guild: Mono<Guild> = Mono.empty(),
+    val channel: Mono<out Channel> = Mono.empty(),
+    val member: Mono<Member> = Mono.empty(),
+    val user: Mono<User> = Mono.empty(),
+)

--- a/src/main/kotlin/xyz/avalonxr/data/format/GuildNameFormatter.kt
+++ b/src/main/kotlin/xyz/avalonxr/data/format/GuildNameFormatter.kt
@@ -1,6 +1,6 @@
 package xyz.avalonxr.data.format
 
-import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.core.`object`.entity.Guild
 import org.springframework.stereotype.Component
 import xyz.avalonxr.models.discord.DiscordStringFormatter
 
@@ -12,12 +12,13 @@ import xyz.avalonxr.models.discord.DiscordStringFormatter
 @Component
 class GuildNameFormatter : DiscordStringFormatter {
 
-    override fun formatWithContext(event: ChatInputInteractionEvent, input: String): String {
-        val guild = event.interaction.guild
+    override fun formatWithContext(context: FormatContext, input: String): String {
+        val guild = context.guild
+            .map(Guild::getName)
             .block()
-            ?.name
-            ?: "Unknown"
+            ?: "[Invalid guild]"
 
-        return input.replace("\${guild}", guild)
+        return input
+            .replace("\${guild}", guild)
     }
 }

--- a/src/main/kotlin/xyz/avalonxr/data/format/TimestampFormatter.kt
+++ b/src/main/kotlin/xyz/avalonxr/data/format/TimestampFormatter.kt
@@ -1,6 +1,5 @@
 package xyz.avalonxr.data.format
 
-import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
 import org.springframework.stereotype.Component
 import xyz.avalonxr.models.discord.DiscordStringFormatter
 
@@ -15,7 +14,7 @@ class TimestampFormatter : DiscordStringFormatter {
     private val now: Long
         get() = System.currentTimeMillis() / 1000
 
-    override fun formatWithContext(event: ChatInputInteractionEvent, input: String): String = input
+    override fun formatWithContext(context: FormatContext, input: String): String = input
         .replace("\${now.date}", "<t:$now:d>")
         .replace("\${now.dateText}", "<t:$now:D>")
         .replace("\${now.time}", "<t:$now:t>")

--- a/src/main/kotlin/xyz/avalonxr/data/format/UsernameFormatter.kt
+++ b/src/main/kotlin/xyz/avalonxr/data/format/UsernameFormatter.kt
@@ -1,6 +1,5 @@
 package xyz.avalonxr.data.format
 
-import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
 import org.springframework.stereotype.Component
 import xyz.avalonxr.models.discord.DiscordStringFormatter
 
@@ -13,13 +12,15 @@ import xyz.avalonxr.models.discord.DiscordStringFormatter
 class UsernameFormatter : DiscordStringFormatter {
 
     override fun formatWithContext(
-        event: ChatInputInteractionEvent,
+        context: FormatContext,
         input: String
     ): String {
-        val user = event.interaction.user
+        val user = context.user.block()
+        val name = user?.username ?: "[Invalid username]"
+        val mention = user?.mention ?: "[Invalid mention]"
 
         return input
-            .replace("\${username.username}", user.username)
-            .replace("\${username.mention}", user.mention)
+            .replace("\${username.username}", name)
+            .replace("\${username.mention}", mention)
     }
 }

--- a/src/main/kotlin/xyz/avalonxr/models/discord/DiscordStringFormatter.kt
+++ b/src/main/kotlin/xyz/avalonxr/models/discord/DiscordStringFormatter.kt
@@ -1,6 +1,6 @@
 package xyz.avalonxr.models.discord
 
-import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import xyz.avalonxr.data.format.FormatContext
 
 /**
  * @author Atri
@@ -14,8 +14,8 @@ interface DiscordStringFormatter {
     /**
      * Formats a given [input] using context provided via an event.
      *
-     * @param event The event which contains the relevant context for formatting with.
+     * @param context The event which contains the relevant context for formatting with.
      * @param input The input string to format.
      */
-    fun formatWithContext(event: ChatInputInteractionEvent, input: String): String
+    fun formatWithContext(context: FormatContext, input: String): String
 }

--- a/src/test/kotlin/xyz/avalonxr/fixtures/data/FormatContextFixture.kt
+++ b/src/test/kotlin/xyz/avalonxr/fixtures/data/FormatContextFixture.kt
@@ -1,0 +1,29 @@
+package xyz.avalonxr.fixtures.data
+
+import discord4j.core.`object`.entity.Guild
+import discord4j.core.`object`.entity.Member
+import discord4j.core.`object`.entity.User
+import discord4j.core.`object`.entity.channel.Channel
+import reactor.core.publisher.Mono
+import xyz.avalonxr.data.format.FormatContext
+import xyz.avalonxr.fixtures.discord.ChannelFixture
+import xyz.avalonxr.fixtures.discord.GuildFixture
+import xyz.avalonxr.fixtures.discord.UserFixture
+
+@Suppress("LocalVariableName")
+object FormatContextFixture {
+
+    fun make(
+        _guild: Guild? = GuildFixture.make(),
+        _channel: Channel? = ChannelFixture.makeGuildChannel(),
+        _user: User? = UserFixture.make(),
+        _member: Member? = null,
+    ): FormatContext = FormatContext(
+        guild = Mono.justOrEmpty(_guild),
+        channel = _channel
+            ?.let { Mono.just(it) }
+            ?: Mono.empty(),
+        user = Mono.justOrEmpty(_user),
+        member = Mono.justOrEmpty(_member),
+    )
+}

--- a/src/test/kotlin/xyz/avalonxr/fixtures/discord/ChannelFixture.kt
+++ b/src/test/kotlin/xyz/avalonxr/fixtures/discord/ChannelFixture.kt
@@ -1,0 +1,17 @@
+package xyz.avalonxr.fixtures.discord
+
+import discord4j.core.`object`.entity.channel.GuildChannel
+import io.mockk.every
+import io.mockk.mockk
+
+@Suppress("LocalVariableName")
+object ChannelFixture {
+
+    fun makeGuildChannel(
+        _name: String? = "bar",
+        _mention: String? = "#bar",
+    ): GuildChannel = mockk {
+        every { name } returns _name
+        every { mention } returns _mention
+    }
+}

--- a/src/test/kotlin/xyz/avalonxr/fixtures/discord/GuildFixture.kt
+++ b/src/test/kotlin/xyz/avalonxr/fixtures/discord/GuildFixture.kt
@@ -1,0 +1,15 @@
+package xyz.avalonxr.fixtures.discord
+
+import discord4j.core.`object`.entity.Guild
+import io.mockk.every
+import io.mockk.mockk
+
+@Suppress("LocalVariableName")
+object GuildFixture {
+
+    fun make(
+        _name: String = "foo",
+    ): Guild = mockk {
+        every { name } returns _name
+    }
+}

--- a/src/test/kotlin/xyz/avalonxr/fixtures/discord/UserFixture.kt
+++ b/src/test/kotlin/xyz/avalonxr/fixtures/discord/UserFixture.kt
@@ -8,8 +8,10 @@ import io.mockk.mockk
 object UserFixture {
 
     fun make(
-        _username: String = "FooBar"
+        _username: String = "FooBar",
+        _mention: String = "@FooBar"
     ): User = mockk {
         every { username } returns _username
+        every { mention } returns _mention
     }
 }

--- a/src/test/kotlin/xyz/avalonxr/service/FormatServiceSpec.kt
+++ b/src/test/kotlin/xyz/avalonxr/service/FormatServiceSpec.kt
@@ -1,0 +1,56 @@
+package xyz.avalonxr.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import xyz.avalonxr.data.format.FormatContext
+import xyz.avalonxr.fixtures.data.FormatContextFixture
+
+@SpringBootTest
+class FormatServiceSpec(
+    private val formatService: FormatService,
+) : DescribeSpec({
+
+    extensions(SpringTestExtension())
+
+    describe("FormatService Tests") {
+
+        describe("formatWithContext") {
+
+            describe("Simple format") {
+                val context = FormatContextFixture.make()
+                val format = "Hello \${username.username}!"
+
+                it("Should format properly") {
+                    formatService
+                        .formatWithContext(context, format)
+                        .shouldBe("Hello FooBar!")
+                }
+            }
+
+            describe("Longer format with channel and guild") {
+                val context = FormatContextFixture.make()
+                val format = "Hello \${username.username}! Welcome to \${guild}, you are in \${channel}"
+
+                it("Should format properly") {
+                    formatService
+                        .formatWithContext(context, format)
+                        .shouldBe("Hello FooBar! Welcome to foo, you are in #bar")
+                }
+            }
+
+            describe("Empty context") {
+                val context = FormatContext()
+                val format = "Hello \${username.username}! Welcome to \${guild}, you are in \${channel}"
+                val expected = "Hello [Invalid username]! Welcome to [Invalid guild], you are in [Invalid channel]"
+
+                it("Should format properly") {
+                    formatService
+                        .formatWithContext(context, format)
+                        .shouldBe(expected)
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
This will decouple or formatting service from a single event type and allow us to specify data associated with a given action. Not all actions will specify or have all data, so this gives us a way to map objects contextually.

Fixes N/A